### PR TITLE
Enable adaptive transparency for Plasma 5.22+

### DIFF
--- a/plasma/desktoptheme/WhiteSur-alt/metadata.desktop
+++ b/plasma/desktoptheme/WhiteSur-alt/metadata.desktop
@@ -15,3 +15,6 @@ defaultWallpaperTheme=WhiteSur
 defaultFileSuffix=.png
 defaultHeight=1440
 defaultWidth=2560
+
+[AdaptiveTransparency]
+enabled = true

--- a/plasma/desktoptheme/WhiteSur-dark/metadata.desktop
+++ b/plasma/desktoptheme/WhiteSur-dark/metadata.desktop
@@ -15,3 +15,6 @@ defaultWallpaperTheme=WhiteSur
 defaultFileSuffix=.png
 defaultHeight=1440
 defaultWidth=2560
+
+[AdaptiveTransparency]
+enabled = true

--- a/plasma/desktoptheme/WhiteSur/metadata.desktop
+++ b/plasma/desktoptheme/WhiteSur/metadata.desktop
@@ -15,3 +15,6 @@ defaultWallpaperTheme=WhiteSur
 defaultFileSuffix=.png
 defaultHeight=1440
 defaultWidth=2560
+
+[AdaptiveTransparency]
+enabled = true


### PR DESCRIPTION
This makes the option available in the panel settings, so users will also be able to disable transparency in addition to making it adaptive. (Adaptive just means that transparency is disabled when an app is maximised, this applies to both the panel and the application launcher)

Screenshot of the new option is below.
![image](https://user-images.githubusercontent.com/18729369/123567242-0aa5b480-d805-11eb-828c-211b29185715.png)
