### PR TITLE
Fix for bottom dock

### DIFF
--- a/plasma/look-and-feel/com.github.vinceliuice.WhiteSur-alt/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/plasma/look-and-feel/com.github.vinceliuice.WhiteSur-alt/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -1,154 +1,50 @@
-var plasma = getApiVersion(1);
+var panel = new Panel
+var panelScreen = panel.screen
 
-var layout = {
-    "desktops": [
-        {
-            "applets": [
-            ],
-            "config": {
-                "/": {
-                    "ItemGeometriesHorizontal": "",
-                    "formfactor": "0",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "540",
-                    "DialogWidth": "720"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                },
-                "/General": {
-                    "ToolBoxButtonState": "bottom",
-                    "ToolBoxButtonX": "739",
-                    "ToolBoxButtonY": "983",
-                    "sortMode": "-1"
-                },
-                "/Wallpaper/org.kde.image/General": {
-                    "Image": "file:///home/vince/Pictures/WhiteSur.png"
-                }
-            },
-            "wallpaperPlugin": "org.kde.image"
-        }
-    ],
-    "panels": [
-        {
-            "alignment": "left",
-            "applets": [
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/General": {
-                            "favoritesPortedToKAstats": "true",
-                            "systemApplications": "systemsettings.desktop,org.kde.kinfocenter.desktop"
-                        },
-                        "/Configuration/Shortcuts": {
-                            "global": "Alt+F1"
-                        },
-                        "/Shortcuts": {
-                            "global": "Alt+F1"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.kickoff"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.appmenu"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.panelspacer"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.systemtray"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/Appearance": {
-                            "fontFamily": "Cantarell",
-                            "showDate": "true",
-                            "spinboxHorizontalPercentage": "50",
-                            "use24hFormat": "2"
-                        },
-                        "/Configuration/ConfigDialog": {
-                            "DialogHeight": "540",
-                            "DialogWidth": "720"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.splitdigitalclock"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "37"
-                        }
-                    },
-                    "plugin": "org.kde.milou"
-                }
-            ],
-            "config": {
-                "/": {
-                    "formfactor": "2",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "74",
-                    "DialogWidth": "1920"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                }
-            },
-            "height": 1.7777777777777777,
-            "hiding": "normal",
-            "location": "top",
-            "maximumLength": 106.66666666666667,
-            "minimumLength": 106.66666666666667,
-            "offset": 0
-        }
-    ],
-    "serializationFormatVersion": "1"
+// No need to set panel.location as ShellCorona::addPanel will automatically pick one available edge
+
+// For an Icons-Only Task Manager on the bottom, *3 is too much, *2 is too little
+// Round down to next highest even number since the Panel size widget only displays
+// even numbers
+panel.height = 2 * Math.floor(gridUnit * 2.5 / 2)
+panel.location = "top"
+
+// Restrict horizontal panel to a maximum size of a 21:9 monitor
+const maximumAspectRatio = 21/9;
+if (panel.formFactor === "horizontal") {
+    const geo = screenGeometry(panelScreen);
+    const maximumWidth = Math.ceil(geo.height * maximumAspectRatio);
+
+    if (geo.width > maximumWidth) {
+        panel.alignment = "center";
+        panel.minimumLength = maximumWidth;
+        panel.maximumLength = maximumWidth;
+    }
 }
-;
 
-plasma.loadSerializedLayout(layout);
+var kickoff = panel.addWidget("org.kde.plasma.kickoff")
+kickoff.currentConfigGroup = ["Shortcuts"]
+kickoff.writeConfig("global", "Alt+F1")
+
+var bpanel = new Panel
+bpanel.location = "bottom"
+bpanel.lengthMode = "fit"
+bpanel.hiding = "dodgewindows"
+bpanel.height = 64
+
+let taskBar = bpanel.addWidget("org.kde.plasma.icontasks")
+taskBar.currentConfigGroup = ["General"]
+taskBar.writeConfig("launchers", [
+    "preferred://filemanager",
+    "preferred://browser",
+    "applications:org.kde.konsole.desktop",
+    "applications:systemsettings.desktop",
+])
+panel.addWidget("org.kde.plasma.appmenu")
+panel.addWidget("org.kde.plasma.panelspacer")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.systemtray")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.digitalclock")
+panel.addWidget("org.kde.plasma.showdesktop")
+

--- a/plasma/look-and-feel/com.github.vinceliuice.WhiteSur-dark/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/plasma/look-and-feel/com.github.vinceliuice.WhiteSur-dark/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -1,154 +1,50 @@
-var plasma = getApiVersion(1);
+var panel = new Panel
+var panelScreen = panel.screen
 
-var layout = {
-    "desktops": [
-        {
-            "applets": [
-            ],
-            "config": {
-                "/": {
-                    "ItemGeometriesHorizontal": "",
-                    "formfactor": "0",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "540",
-                    "DialogWidth": "720"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                },
-                "/General": {
-                    "ToolBoxButtonState": "bottom",
-                    "ToolBoxButtonX": "739",
-                    "ToolBoxButtonY": "983",
-                    "sortMode": "-1"
-                },
-                "/Wallpaper/org.kde.image/General": {
-                    "Image": "file:///home/vince/Pictures/WhiteSur.png"
-                }
-            },
-            "wallpaperPlugin": "org.kde.image"
-        }
-    ],
-    "panels": [
-        {
-            "alignment": "left",
-            "applets": [
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/General": {
-                            "favoritesPortedToKAstats": "true",
-                            "systemApplications": "systemsettings.desktop,org.kde.kinfocenter.desktop"
-                        },
-                        "/Configuration/Shortcuts": {
-                            "global": "Alt+F1"
-                        },
-                        "/Shortcuts": {
-                            "global": "Alt+F1"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.kickoff"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.appmenu"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.panelspacer"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.systemtray"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/Appearance": {
-                            "fontFamily": "Cantarell",
-                            "showDate": "true",
-                            "spinboxHorizontalPercentage": "50",
-                            "use24hFormat": "2"
-                        },
-                        "/Configuration/ConfigDialog": {
-                            "DialogHeight": "540",
-                            "DialogWidth": "720"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.splitdigitalclock"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "37"
-                        }
-                    },
-                    "plugin": "org.kde.milou"
-                }
-            ],
-            "config": {
-                "/": {
-                    "formfactor": "2",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "74",
-                    "DialogWidth": "1920"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                }
-            },
-            "height": 1.7777777777777777,
-            "hiding": "normal",
-            "location": "top",
-            "maximumLength": 106.66666666666667,
-            "minimumLength": 106.66666666666667,
-            "offset": 0
-        }
-    ],
-    "serializationFormatVersion": "1"
+// No need to set panel.location as ShellCorona::addPanel will automatically pick one available edge
+
+// For an Icons-Only Task Manager on the bottom, *3 is too much, *2 is too little
+// Round down to next highest even number since the Panel size widget only displays
+// even numbers
+panel.height = 2 * Math.floor(gridUnit * 2.5 / 2)
+panel.location = "top"
+
+// Restrict horizontal panel to a maximum size of a 21:9 monitor
+const maximumAspectRatio = 21/9;
+if (panel.formFactor === "horizontal") {
+    const geo = screenGeometry(panelScreen);
+    const maximumWidth = Math.ceil(geo.height * maximumAspectRatio);
+
+    if (geo.width > maximumWidth) {
+        panel.alignment = "center";
+        panel.minimumLength = maximumWidth;
+        panel.maximumLength = maximumWidth;
+    }
 }
-;
 
-plasma.loadSerializedLayout(layout);
+var kickoff = panel.addWidget("org.kde.plasma.kickoff")
+kickoff.currentConfigGroup = ["Shortcuts"]
+kickoff.writeConfig("global", "Alt+F1")
+
+var bpanel = new Panel
+bpanel.location = "bottom"
+bpanel.lengthMode = "fit"
+bpanel.hiding = "dodgewindows"
+bpanel.height = 64
+
+let taskBar = bpanel.addWidget("org.kde.plasma.icontasks")
+taskBar.currentConfigGroup = ["General"]
+taskBar.writeConfig("launchers", [
+    "preferred://filemanager",
+    "preferred://browser",
+    "applications:org.kde.konsole.desktop",
+    "applications:systemsettings.desktop",
+])
+panel.addWidget("org.kde.plasma.appmenu")
+panel.addWidget("org.kde.plasma.panelspacer")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.systemtray")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.digitalclock")
+panel.addWidget("org.kde.plasma.showdesktop")
+

--- a/plasma/look-and-feel/com.github.vinceliuice.WhiteSur/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/plasma/look-and-feel/com.github.vinceliuice.WhiteSur/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -1,154 +1,50 @@
-var plasma = getApiVersion(1);
+var panel = new Panel
+var panelScreen = panel.screen
 
-var layout = {
-    "desktops": [
-        {
-            "applets": [
-            ],
-            "config": {
-                "/": {
-                    "ItemGeometriesHorizontal": "",
-                    "formfactor": "0",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "540",
-                    "DialogWidth": "720"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                },
-                "/General": {
-                    "ToolBoxButtonState": "bottom",
-                    "ToolBoxButtonX": "739",
-                    "ToolBoxButtonY": "983",
-                    "sortMode": "-1"
-                },
-                "/Wallpaper/org.kde.image/General": {
-                    "Image": "file:///home/vince/Pictures/WhiteSur.png"
-                }
-            },
-            "wallpaperPlugin": "org.kde.image"
-        }
-    ],
-    "panels": [
-        {
-            "alignment": "left",
-            "applets": [
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/General": {
-                            "favoritesPortedToKAstats": "true",
-                            "systemApplications": "systemsettings.desktop,org.kde.kinfocenter.desktop"
-                        },
-                        "/Configuration/Shortcuts": {
-                            "global": "Alt+F1"
-                        },
-                        "/Shortcuts": {
-                            "global": "Alt+F1"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.kickoff"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.appmenu"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "0"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.panelspacer"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.systemtray"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "100"
-                        },
-                        "/Configuration/Appearance": {
-                            "fontFamily": "Cantarell",
-                            "showDate": "true",
-                            "spinboxHorizontalPercentage": "50",
-                            "use24hFormat": "2"
-                        },
-                        "/Configuration/ConfigDialog": {
-                            "DialogHeight": "540",
-                            "DialogWidth": "720"
-                        }
-                    },
-                    "plugin": "org.kde.plasma.splitdigitalclock"
-                },
-                {
-                    "config": {
-                        "/": {
-                            "immutability": "1"
-                        },
-                        "/Configuration": {
-                            "PreloadWeight": "37"
-                        }
-                    },
-                    "plugin": "org.kde.milou"
-                }
-            ],
-            "config": {
-                "/": {
-                    "formfactor": "2",
-                    "immutability": "1",
-                    "lastScreen": "0",
-                    "wallpaperplugin": "org.kde.image"
-                },
-                "/ConfigDialog": {
-                    "DialogHeight": "74",
-                    "DialogWidth": "1920"
-                },
-                "/Configuration": {
-                    "PreloadWeight": "0"
-                }
-            },
-            "height": 1.7777777777777777,
-            "hiding": "normal",
-            "location": "top",
-            "maximumLength": 106.66666666666667,
-            "minimumLength": 106.66666666666667,
-            "offset": 0
-        }
-    ],
-    "serializationFormatVersion": "1"
+// No need to set panel.location as ShellCorona::addPanel will automatically pick one available edge
+
+// For an Icons-Only Task Manager on the bottom, *3 is too much, *2 is too little
+// Round down to next highest even number since the Panel size widget only displays
+// even numbers
+panel.height = 2 * Math.floor(gridUnit * 2.5 / 2)
+panel.location = "top"
+
+// Restrict horizontal panel to a maximum size of a 21:9 monitor
+const maximumAspectRatio = 21/9;
+if (panel.formFactor === "horizontal") {
+    const geo = screenGeometry(panelScreen);
+    const maximumWidth = Math.ceil(geo.height * maximumAspectRatio);
+
+    if (geo.width > maximumWidth) {
+        panel.alignment = "center";
+        panel.minimumLength = maximumWidth;
+        panel.maximumLength = maximumWidth;
+    }
 }
-;
 
-plasma.loadSerializedLayout(layout);
+var kickoff = panel.addWidget("org.kde.plasma.kickoff")
+kickoff.currentConfigGroup = ["Shortcuts"]
+kickoff.writeConfig("global", "Alt+F1")
+
+var bpanel = new Panel
+bpanel.location = "bottom"
+bpanel.lengthMode = "fit"
+bpanel.hiding = "dodgewindows"
+bpanel.height = 64
+
+let taskBar = bpanel.addWidget("org.kde.plasma.icontasks")
+taskBar.currentConfigGroup = ["General"]
+taskBar.writeConfig("launchers", [
+    "preferred://filemanager",
+    "preferred://browser",
+    "applications:org.kde.konsole.desktop",
+    "applications:systemsettings.desktop",
+])
+panel.addWidget("org.kde.plasma.appmenu")
+panel.addWidget("org.kde.plasma.panelspacer")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.systemtray")
+panel.addWidget("org.kde.plasma.marginsseparator")
+panel.addWidget("org.kde.plasma.digitalclock")
+panel.addWidget("org.kde.plasma.showdesktop")
+


### PR DESCRIPTION
I fixed the default desktop layout by adding KDE icon only bottom dock like macos containing default file explorer and default web browser and konsole and system settings.